### PR TITLE
editorconfig file added

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[{src}/**.{ts,tsx,json,js,jsx}]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+


### PR DESCRIPTION
see if you agree with the options I specified here. Atom doesn't seem to complain much about anything except it removes whitespace at the end of a line and uses the correct LF or CRLF. Maybe Visual Studio Code is smarter/more strict?