### PR TITLE
Purity refactor

### DIFF
--- a/src/actions/childrenRequestedThunk.tsx
+++ b/src/actions/childrenRequestedThunk.tsx
@@ -47,7 +47,7 @@ export const childrenRequestedThunk = (id: number) => {
 
         dispatch(childrenRequested());
 
-        const url: string = 'http://localhost:5000/node/' + id.toString() + '/children';
+        const url: string = 'http://localhost:5000/entities/' + id.toString() + '/children';
 
         fetch(url, {method: 'get'})
                 .then(handleTheStatus)

--- a/src/actions/rootRequestedThunk.tsx
+++ b/src/actions/rootRequestedThunk.tsx
@@ -23,15 +23,12 @@ export const rootRequestedThunk = () => {
         const handleTheData = (dbrecords: any) => {
             const convert = (dbrecord: IDatabaseRecord) => {
                 return {
-                    parent:         -1,
+                    parent:         dbrecord.childof,
                     id:             dbrecord.id,
-                    isentity:       dbrecord.isentity === 1 ? true : false,
-                    isleaf:         dbrecord.isleaf === 1 ? true : false,
                     isinstance:     dbrecord.isinstance === 1 ? true : false,
                     level:          dbrecord.level,
                     mentioncount:   dbrecord.mentioncount,
                     name:           dbrecord.name,
-                    url:            dbrecord.url,
                     isexpanded:     false,
                     selectionState: SelectionState.Unselected,
                     children:       []
@@ -49,7 +46,7 @@ export const rootRequestedThunk = () => {
 
         dispatch(rootRequested());
 
-        const url: string = 'http://localhost:5000/node/' + '0' + '/children';
+        const url: string = 'http://localhost:5000/entities/' + '1' + '/children';
 
         fetch(url, {method: 'get'})
                 .then(handleTheStatus)

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -22,13 +22,10 @@ interface IExtraProps {
 export interface INode {
     parent: number;
     id: number;
-    isentity: boolean;
-    isleaf: boolean;
     isinstance: boolean;
     level: number;
     mentioncount: number;
     name: string;
-    url: string;
     isexpanded: boolean;
     selectionState: SelectionState;
     children: number[];
@@ -55,15 +52,12 @@ export class UnconnectedNode extends React.Component<IExtraProps & INode & INode
             return {
                 nodeID: dbid,
 
-                parent: -1,
+                parent: 1,
                 id: dbid,
-                isentity: false,
-                isleaf: false,
                 isinstance: false,
                 level: 0,
                 mentioncount: 0,
                 name: 'undefined',
-                url: 'un.defi.ned',
                 isexpanded: false,
                 selectionState: SelectionState.Unselected,
                 children: []
@@ -74,13 +68,10 @@ export class UnconnectedNode extends React.Component<IExtraProps & INode & INode
 
                 parent: state.nodes[dbid].childof,
                 id: state.nodes[dbid].id,
-                isentity: state.nodes[dbid].isentity,
-                isleaf: state.nodes[dbid].isleaf,
                 isinstance: state.nodes[dbid].isinstance,
                 level: state.nodes[dbid].level,
                 mentioncount: state.nodes[dbid].mentioncount,
                 name: state.nodes[dbid].name,
-                url: state.nodes[dbid].url,
                 isexpanded: state.nodes[dbid].isexpanded,
                 selectionState: state.nodes[dbid].selectionState,
                 children: state.nodes[dbid].children

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { store }       from './store';
 
 ReactDOM.render(
     <Provider store={store}>
-        <Node key={1} nodeID={1} />
+        <Node key={2} nodeID={2} />
     </Provider>,
     document.getElementById('root')
 );

--- a/src/reducers/nodesReducer.ts
+++ b/src/reducers/nodesReducer.ts
@@ -39,7 +39,7 @@ export const nodesReducer = (nodes: any = initstate, action: IGenericAction) => 
         const selectedNode = nodes[selectionID];
 
         const parentID = selectedNode.parent;
-        if (parentID !== -1) {
+        if (parentID !== 1) {
             const parentNode = nodes[parentID];
 
             //The children of our parent are our siblings


### PR DESCRIPTION
whazzup. I noticed in the debugger we had the ``nodes`` part of our state change retroactively. So after you do a state change, the ``console.log``'ed ``nodes`` from _before_ the state change becomes equal to the state _after_ the state change...this is not how it's supposed to be, so this PR attempt to correct  that.
