### PR TITLE
Aggregate selected data on Build Query Button click

### DIFF
--- a/src/actions/authorized-actions.ts
+++ b/src/actions/authorized-actions.ts
@@ -1,5 +1,13 @@
 import { INode } from '../components/Node';
 
+export const ROOT_REQUESTED = 'ROOT_REQUESTED';
+export interface IRootRequestedAction {
+    type: 'ROOT_REQUESTED';
+    payload: {
+        table: string
+    };
+}
+
 export const ROOT_RECEIVED = 'ROOT_RECEIVED';
 export interface IRootReceivedAction {
     type: 'ROOT_RECEIVED';
@@ -9,9 +17,9 @@ export interface IRootReceivedAction {
     };
 }
 
-export const ROOT_REQUESTED = 'ROOT_REQUESTED';
-export interface IRootRequestedAction {
-    type: 'ROOT_REQUESTED';
+export const CHILDREN_REQUESTED = 'CHILDREN_REQUESTED';
+export interface IChildrenRequestedAction {
+    type: 'CHILDREN_REQUESTED';
     payload: {
         table: string
     };
@@ -23,14 +31,6 @@ export interface IChildrenReceivedAction {
     payload: {
         table: string,
         nodes: any
-    };
-}
-
-export const CHILDREN_REQUESTED = 'CHILDREN_REQUESTED';
-export interface IChildrenRequestedAction {
-    type: 'CHILDREN_REQUESTED';
-    payload: {
-        table: string
     };
 }
 
@@ -52,9 +52,51 @@ export interface ISelectionWasClickedAction {
     };
 }
 
+export const CLEAR_QUERY = 'CLEAR_QUERY';
+export interface IClearQueryAction {
+    type: 'CLEAR_QUERY';
+    payload: {
+    };
+}
+
 export const BUILD_QUERY = 'BUILD_QUERY';
 export interface IBuildQueryAction {
     type: 'BUILD_QUERY';
+    payload: {
+    };
+}
+
+export const STORE_QUERY = 'STORE_QUERY';
+export interface IStoreQueryAction {
+    type: 'STORE_QUERY';
+    payload: {
+    };
+}
+
+export const OPEN_BUILD_QUERY_DIALOG = 'OPEN_BUILD_QUERY_DIALOG';
+export interface IStoreOpenBuildQueryDialogAction {
+    type: 'OPEN_BUILD_QUERY_DIALOG';
+    payload: {
+    };
+}
+
+export const CLOSE_BUILD_QUERY_DIALOG = 'CLOSE_BUILD_QUERY_DIALOG';
+export interface IStoreCloseBuildQueryDialogAction {
+    type: 'CLOSE_BUILD_QUERY_DIALOG';
+    payload: {
+    };
+}
+
+export const OPEN_CLEAR_QUERY_DIALOG = 'OPEN_CLEAR_QUERY_DIALOG';
+export interface IStoreOpenClearQueryDialogAction {
+    type: 'OPEN_CLEAR_QUERY_DIALOG';
+    payload: {
+    };
+}
+
+export const CLOSE_CLEAR_QUERY_DIALOG = 'CLOSE_CLEAR_QUERY_DIALOG';
+export interface IStoreCloseClearQueryDialogAction {
+    type: 'CLOSE_CLEAR_QUERY_DIALOG';
     payload: {
     };
 }

--- a/src/actions/authorized-actions.ts
+++ b/src/actions/authorized-actions.ts
@@ -100,3 +100,21 @@ export interface IStoreCloseClearQueryDialogAction {
     payload: {
     };
 }
+
+export const TEXT_SEARCH = 'TEXT_SEARCH';
+export interface ITextSearchAction {
+    type: 'TEXT_SEARCH';
+    payload: {
+        table: string,
+        input: string
+    };
+}
+
+export const TEXT_SEARCH_RESULT_RECEIVED = 'TEXT_SEARCH_RESULT_RECEIVED';
+export interface ITextSearchResultReceivedAction {
+    type: 'TEXT_SEARCH_RESULT_RECEIVED';
+    payload: {
+        table: string,
+        nodes: number[]
+    };
+}

--- a/src/actions/authorized-actions.ts
+++ b/src/actions/authorized-actions.ts
@@ -51,3 +51,10 @@ export interface ISelectionWasClickedAction {
         id: number
     };
 }
+
+export const BUILD_QUERY = 'BUILD_QUERY';
+export interface IBuildQueryAction {
+    type: 'BUILD_QUERY';
+    payload: {
+    };
+}

--- a/src/actions/buildQuery.ts
+++ b/src/actions/buildQuery.ts
@@ -1,0 +1,8 @@
+import { BUILD_QUERY }    from './authorized-actions';
+
+export const buildQuery = () => {
+    return {
+        type: BUILD_QUERY,
+        payload: {}
+    };
+};

--- a/src/actions/childrenRequestedThunk.tsx
+++ b/src/actions/childrenRequestedThunk.tsx
@@ -29,7 +29,8 @@ export const childrenRequestedThunk = (table: string, id: number) => {
                     mentioncount:   dbrecord.mentioncount,
                     name:           dbrecord.name,
                     parent:         dbrecord.childof,
-                    selectionState: SelectionState.Unselected
+                    selectionState: SelectionState.Unselected,
+                    highlighted:    false
                 } as INode;
             };
 

--- a/src/actions/clearQuery.ts
+++ b/src/actions/clearQuery.ts
@@ -1,0 +1,8 @@
+import { CLEAR_QUERY }    from './authorized-actions';
+
+export const clearQuery = () => {
+    return {
+        type: CLEAR_QUERY,
+        payload: {}
+    };
+};

--- a/src/actions/closeBuildQueryDialog.ts
+++ b/src/actions/closeBuildQueryDialog.ts
@@ -1,0 +1,8 @@
+import { CLOSE_BUILD_QUERY_DIALOG }    from './authorized-actions';
+
+export const closeBuildQueryDialog = () => {
+    return {
+        type: CLOSE_BUILD_QUERY_DIALOG,
+        payload: {}
+    };
+};

--- a/src/actions/closeClearQueryDialog.ts
+++ b/src/actions/closeClearQueryDialog.ts
@@ -1,0 +1,8 @@
+import { CLOSE_CLEAR_QUERY_DIALOG }    from './authorized-actions';
+
+export const closeClearQueryDialog = () => {
+    return {
+        type: CLOSE_CLEAR_QUERY_DIALOG,
+        payload: {}
+    };
+};

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,22 +1,44 @@
-// string constants: names of actions
-export { EXPAND_BUTTON_WAS_CLICKED }  from './authorized-actions';
-export { CHILDREN_RECEIVED }          from './authorized-actions';
-export { CHILDREN_REQUESTED }         from './authorized-actions';
-export { ROOT_RECEIVED }              from './authorized-actions';
-export { ROOT_REQUESTED }             from './authorized-actions';
-export { SELECTION_WAS_CLICKED }      from './authorized-actions';
-
-export { BUILD_QUERY }                from './authorized-actions';
-
 // export generic action type
 export { IGenericAction }             from './IGenericAction';
 
-// action generators
-export { childrenRequestedThunk }     from './childrenRequestedThunk';
-export { rootRequestedThunk }         from './rootRequestedThunk';
+//Export action types
+export { EXPAND_BUTTON_WAS_CLICKED }  from './authorized-actions';
 export { expandButtonWasClicked }     from './expandButtonWasClicked';
+
+export { CHILDREN_REQUESTED }         from './authorized-actions';
+export { childrenRequestedThunk }     from './childrenRequestedThunk';
 export { childrenRequested }          from './childrenRequested';
+
+export { CHILDREN_RECEIVED }          from './authorized-actions';
+export { childrenReceived }          from './childrenReceived';
+
+export { ROOT_REQUESTED }             from './authorized-actions';
+export { rootRequestedThunk }         from './rootRequestedThunk';
 export { rootRequested }              from './rootRequested';
+
+export { ROOT_RECEIVED }              from './authorized-actions';
+export { rootReceived }               from './rootReceived';
+
+export { SELECTION_WAS_CLICKED }      from './authorized-actions';
 export { selectionWasClicked }        from './selectionWasClicked';
 
+export { CLEAR_QUERY }                from './authorized-actions';
+export { clearQuery }                 from './clearQuery';
+
+export { BUILD_QUERY }                from './authorized-actions';
 export { buildQuery }                 from './buildQuery';
+
+export { STORE_QUERY }                from './authorized-actions';
+export { storeQuery }                 from './storeQuery';
+
+export { OPEN_BUILD_QUERY_DIALOG }    from './authorized-actions';
+export { openBuildQueryDialog }       from './openBuildQueryDialog';
+
+export { CLOSE_BUILD_QUERY_DIALOG }   from './authorized-actions';
+export { closeBuildQueryDialog }      from './closeBuildQueryDialog';
+
+export { OPEN_CLEAR_QUERY_DIALOG }    from './authorized-actions';
+export { openClearQueryDialog }       from './openClearQueryDialog';
+
+export { CLOSE_CLEAR_QUERY_DIALOG }   from './authorized-actions';
+export { closeClearQueryDialog }      from './closeClearQueryDialog';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -10,7 +10,7 @@ export { childrenRequestedThunk }     from './childrenRequestedThunk';
 export { childrenRequested }          from './childrenRequested';
 
 export { CHILDREN_RECEIVED }          from './authorized-actions';
-export { childrenReceived }          from './childrenReceived';
+export { childrenReceived }           from './childrenReceived';
 
 export { ROOT_REQUESTED }             from './authorized-actions';
 export { rootRequestedThunk }         from './rootRequestedThunk';
@@ -42,3 +42,10 @@ export { openClearQueryDialog }       from './openClearQueryDialog';
 
 export { CLOSE_CLEAR_QUERY_DIALOG }   from './authorized-actions';
 export { closeClearQueryDialog }      from './closeClearQueryDialog';
+
+export { TEXT_SEARCH }                from './authorized-actions';
+export { textSearch }                 from './textSearch';
+export { textSearchThunk }            from './textSearchThunk';
+
+export { TEXT_SEARCH_RESULT_RECEIVED }from './authorized-actions';
+export { textSearchResultReceived }   from './textSearchResultReceived';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -6,6 +6,8 @@ export { ROOT_RECEIVED }              from './authorized-actions';
 export { ROOT_REQUESTED }             from './authorized-actions';
 export { SELECTION_WAS_CLICKED }      from './authorized-actions';
 
+export { BUILD_QUERY }                from './authorized-actions';
+
 // export generic action type
 export { IGenericAction }             from './IGenericAction';
 
@@ -16,3 +18,5 @@ export { expandButtonWasClicked }     from './expandButtonWasClicked';
 export { childrenRequested }          from './childrenRequested';
 export { rootRequested }              from './rootRequested';
 export { selectionWasClicked }        from './selectionWasClicked';
+
+export { buildQuery }                 from './buildQuery';

--- a/src/actions/openBuildQueryDialog.ts
+++ b/src/actions/openBuildQueryDialog.ts
@@ -1,0 +1,8 @@
+import { OPEN_BUILD_QUERY_DIALOG }    from './authorized-actions';
+
+export const openBuildQueryDialog = () => {
+    return {
+        type: OPEN_BUILD_QUERY_DIALOG,
+        payload: {}
+    };
+};

--- a/src/actions/openClearQueryDialog.ts
+++ b/src/actions/openClearQueryDialog.ts
@@ -1,0 +1,8 @@
+import { OPEN_CLEAR_QUERY_DIALOG }    from './authorized-actions';
+
+export const openClearQueryDialog = () => {
+    return {
+        type: OPEN_CLEAR_QUERY_DIALOG,
+        payload: {}
+    };
+};

--- a/src/actions/rootRequestedThunk.tsx
+++ b/src/actions/rootRequestedThunk.tsx
@@ -30,7 +30,8 @@ export const rootRequestedThunk = (table: string) => {
                     mentioncount:   dbrecord.mentioncount,
                     name:           dbrecord.name,
                     parent:         dbrecord.childof,
-                    selectionState: SelectionState.Unselected
+                    selectionState: SelectionState.Unselected,
+                    highlighted:    false
                 } as INode;
             };
             //Since this is the root, we expect only 1 element, and therefore 

--- a/src/actions/storeQuery.ts
+++ b/src/actions/storeQuery.ts
@@ -1,0 +1,8 @@
+import { STORE_QUERY }    from './authorized-actions';
+
+export const storeQuery = () => {
+    return {
+        type: STORE_QUERY,
+        payload: { }
+    };
+};

--- a/src/actions/textSearch.ts
+++ b/src/actions/textSearch.ts
@@ -1,0 +1,8 @@
+import { TEXT_SEARCH }    from './authorized-actions';
+
+export const textSearch = (table: string, input: string) => {
+    return {
+        type: TEXT_SEARCH,
+        payload: { table, input }
+    };
+};

--- a/src/actions/textSearchResultReceived.ts
+++ b/src/actions/textSearchResultReceived.ts
@@ -1,0 +1,8 @@
+import { TEXT_SEARCH_RESULT_RECEIVED }    from './authorized-actions';
+
+export const textSearchResultReceived = (table: string, nodes: number[]) => {
+    return {
+        type: TEXT_SEARCH_RESULT_RECEIVED,
+        payload: { table, nodes }
+    };
+};

--- a/src/actions/textSearchThunk.tsx
+++ b/src/actions/textSearchThunk.tsx
@@ -1,0 +1,45 @@
+import { Dispatch }                             from 'redux';
+
+import { IGenericAction }                       from '../actions';
+import { textSearch }                           from './textSearch';
+import { textSearchResultReceived }             from './textSearchResultReceived';
+
+export interface IDatabaseNumberRecord {
+    parentID: number;
+}
+
+export const textSearchThunk = (table: string, input: string) => {
+    return (dispatch: Dispatch<IGenericAction>) => {
+        const handleTheStatus = (response: Response) => {
+            if (response.ok) {
+                return response.json();
+            } else {
+                throw new Error('Error when trying to retrieve the data. ' +
+                    'status text: \"' + response.statusText + '".');
+            }
+        };
+
+        const handleTheData = (dbrecords: any) => {
+            const convert = (dbrecord: IDatabaseNumberRecord) => {
+                return dbrecord.parentID as number;
+            };
+
+            const nodes: number[] = dbrecords.map(convert);
+            dispatch(textSearchResultReceived(table, nodes));
+        };
+
+        const handleAnyErrors = () => {
+            dispatch(textSearchResultReceived(table, []));
+            // throw new Error('Errors occured. ' + err.message + err.stack);
+        };
+
+        dispatch(textSearch(table, input));
+
+        const url: string = 'http://localhost:5000/search/' + table + '/' + input;
+
+        fetch(url, {method: 'get'})
+                .then(handleTheStatus)
+                .then(handleTheData)
+                .catch(handleAnyErrors);
+    };
+};

--- a/src/components/MentionCounter.tsx
+++ b/src/components/MentionCounter.tsx
@@ -30,7 +30,7 @@ export class UnconnectedMentionCounter extends React.Component<IMentionCounter, 
 
     render() {
         return (
-            <div className="mdl-textfield mdl-js-textfield">
+            <div className="mdl-textfield mdl-js-textfield mentioncounter">
                 Selected Mentions: {this.props.selectedMentionCount ? this.props.selectedMentionCount : 0}
             </div>
         );

--- a/src/components/MentionCounter.tsx
+++ b/src/components/MentionCounter.tsx
@@ -1,0 +1,42 @@
+import * as React                   from 'react';
+
+import { connect }                  from 'react-redux';
+
+import { IStore }                   from '../interfaces';
+
+import './mentionCounter.css';
+
+export interface IMentionCounter {
+    id: number;
+    selectedMentionCount: number;
+}
+
+export class UnconnectedMentionCounter extends React.Component<IMentionCounter, {}> {
+    constructor() {
+        super();
+    }
+
+    static mapStateToProps(state: IStore) { //state: IStore) {
+        return {
+            id:  -1,
+            selectedMentionCount: state.queryState.selectedMentionCount
+        };
+    }
+
+    static mapDispatchToProps() {
+        return {
+        };
+    }
+
+    render() {
+        return (
+            <div className="mdl-textfield mdl-js-textfield">
+                Selected Mentions: {this.props.selectedMentionCount ? this.props.selectedMentionCount : 0}
+            </div>
+        );
+    }
+}
+
+// Export just the connected component
+export const MentionCounter = connect(UnconnectedMentionCounter.mapStateToProps,
+                                      UnconnectedMentionCounter.mapDispatchToProps)(UnconnectedMentionCounter);

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -26,6 +26,7 @@ export interface INode {
     name: string;
     parent: number;
     selectionState: SelectionState;
+    highlighted: boolean;
 }
 
 export class UnconnectedNode extends React.Component<IExtraProps & INode, {}> {
@@ -57,7 +58,8 @@ export class UnconnectedNode extends React.Component<IExtraProps & INode, {}> {
                 name: 'undefined',
                 nodeID: dbid,
                 parent: -1,
-                selectionState: SelectionState.Unselected
+                selectionState: SelectionState.Unselected,
+                highlighted: false
             };
         } else {
             return {
@@ -69,7 +71,8 @@ export class UnconnectedNode extends React.Component<IExtraProps & INode, {}> {
                 name: nodes[dbid].name,
                 nodeID: dbid,
                 parent: nodes[dbid].childof,
-                selectionState: nodes[dbid].selectionState
+                selectionState: nodes[dbid].selectionState,
+                highlighted: nodes[dbid].highlighted
             };
         }
     }
@@ -90,7 +93,7 @@ export class UnconnectedNode extends React.Component<IExtraProps & INode, {}> {
                 );
             }
             return (
-                <Grid className={'mdl-cell--12-col category'}>
+                <Grid className={this.props.highlighted ? 'mdl-cell--12-col category highlighted' : 'mdl-cell--12-col category'}>
                     <Cell col={12} className="categoryTitleBar">
                         <NodeCheckbox table={this.props.table} nodeID={this.props.id} />
                         <NodeCategory table={this.props.table} nodeID={this.props.id} />

--- a/src/components/NodeCheckbox.tsx
+++ b/src/components/NodeCheckbox.tsx
@@ -4,6 +4,7 @@ import { Dispatch }                 from 'redux';
 
 import { IGenericAction }           from '../actions';
 import { selectionWasClicked }      from '../actions';
+import { buildQuery }               from '../actions';
 
 import Checkbox                     from '../Checkbox/Checkbox';
 
@@ -18,6 +19,7 @@ interface IExtraProps {
 }
 
 interface INodeDispatchProps {
+    buildQuery: () => void;
     toggleSelection: (table: string, id: number) => void;
 }
 
@@ -66,6 +68,9 @@ export class UnconnectedNodeCheckbox extends React.Component<IExtraProps & INode
 
     static mapDispatchToProps(dispatch: Dispatch<IGenericAction>) {
         return {
+            buildQuery: () => {
+                dispatch(buildQuery());
+            },
             toggleSelection: (table: string, id: number) => {
                 dispatch(selectionWasClicked(table, id));
             }
@@ -74,6 +79,7 @@ export class UnconnectedNodeCheckbox extends React.Component<IExtraProps & INode
 
     public onClickSelect() {
         this.props.toggleSelection(this.props.table, this.props.id);
+        this.props.buildQuery();
     }
 
     render() {

--- a/src/components/NodeInstance.tsx
+++ b/src/components/NodeInstance.tsx
@@ -81,7 +81,7 @@ export class UnconnectedNodeInstance extends React.Component<IExtraProps & INode
 
     render() {
         return (
-            <Button raised accent={this.props.selectionState === SelectionState.Selected} onClick={this.onClickSelect}>
+            <Button raised colored={this.props.selectionState === SelectionState.Selected} onClick={this.onClickSelect}>
                 {this.props.name}
             </Button>
         );

--- a/src/components/QueryBuildButton.tsx
+++ b/src/components/QueryBuildButton.tsx
@@ -1,20 +1,33 @@
 import * as React                   from 'react';
+
 import { connect }                  from 'react-redux';
 import { Dispatch }                 from 'redux';
 
 import { IGenericAction }           from '../actions';
 import { buildQuery }               from '../actions';
+import { storeQuery }               from '../actions';
+import { openBuildQueryDialog }     from '../actions';
+import { closeBuildQueryDialog }    from '../actions';
 
-import { Button }                   from 'react-mdl';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from 'react-mdl';
+
+import { IStore }                   from '../interfaces';
 
 import './queryBuildButton.css';
+import './queryDialog.css';
 
 interface IQueryBuildButtonDispatchProps {
     buildQuery: () => void;
+    storeQuery: () => void;
+    openDialog: () => void;
+    closeDialog: () => void;
 }
 
 export interface IQueryBuildButton {
     id: number;
+    query: any;
+    dialogOpen: boolean;
+    buttonActive: boolean;
 }
 
 export class UnconnectedQueryBuildButton extends React.Component<IQueryBuildButton & IQueryBuildButtonDispatchProps, {}> {
@@ -22,11 +35,27 @@ export class UnconnectedQueryBuildButton extends React.Component<IQueryBuildButt
         super();
 
         this.onClick = this.onClick.bind(this);
+        this.clickStoreQuery = this.clickStoreQuery.bind(this);
+        this.handleOpenDialog = this.handleOpenDialog.bind(this);
+        this.handleCloseDialog = this.handleCloseDialog.bind(this);
     }
 
-    static mapStateToProps() { //state: IStore) {
+    static shouldButtonBeActive(state: IStore): boolean {
+        if ((state.queryState.entities  && state.queryState.entities.length > 0) ||
+            (state.queryState.events    && state.queryState.events.length > 0) ||
+            (state.queryState.sources   && state.queryState.sources.length > 0) ||
+            (state.queryState.topics    && state.queryState.topics.length > 0)) {
+            return true;
+        }
+        return false;
+    }
+
+    static mapStateToProps(state: IStore) { //state: IStore) {
         return {
-            id:  -1
+            id:  -1,
+            query: state.queryState,
+            dialogOpen: state.queryState.isQueryBuildDialogOpen,
+            buttonActive: UnconnectedQueryBuildButton.shouldButtonBeActive(state)
         };
     }
 
@@ -34,19 +63,100 @@ export class UnconnectedQueryBuildButton extends React.Component<IQueryBuildButt
         return {
             buildQuery: () => {
                 dispatch(buildQuery());
+            },
+            storeQuery: () => {
+                dispatch(storeQuery());
+            },
+            openDialog: () => {
+                dispatch(openBuildQueryDialog());
+            },
+            closeDialog: () => {
+                dispatch(closeBuildQueryDialog());
             }
         };
     }
 
     public onClick() {
         this.props.buildQuery();
+        this.props.openDialog();
+    }
+
+    public clickStoreQuery() {
+        this.props.storeQuery();
+        this.props.closeDialog();
+    }
+
+    public handleOpenDialog() {
+        this.props.openDialog();
+    }
+
+    public handleCloseDialog() {
+        this.props.closeDialog();
     }
 
     render() {
+        let queryEntities: JSX.Element[] = [];
+        if (this.props.query !== undefined && this.props.query.entities !== undefined) {
+            const temp: any[] = this.props.query.entities;
+            queryEntities = temp.map((queryEntity: any) =>
+                <div key={queryEntity.name}>{queryEntity.name}</div>
+            );
+        }
+        let queryEvents: JSX.Element[] = [];
+        if (this.props.query !== undefined && this.props.query.events !== undefined) {
+            const temp: any[] = this.props.query.events;
+            queryEvents = temp.map((queryEvent: any) =>
+                <div key={queryEvent.name}>{queryEvent.name}</div>
+            );
+        }
+        let querySources: JSX.Element[] = [];
+        if (this.props.query !== undefined && this.props.query.sources !== undefined) {
+            const temp: any[] = this.props.query.sources;
+            querySources = temp.map((querySource: any) =>
+                <div key={querySource.name}>{querySource.name}</div>
+            );
+        }
+        let queryTopics: JSX.Element[] = [];
+        if (this.props.query !== undefined && this.props.query.topics !== undefined) {
+            const temp: any[] = this.props.query.topics;
+            queryTopics = temp.map((queryTopic: any) =>
+                <div key={queryTopic.name}>{queryTopic.name}</div>
+            );
+        }
         return (
-            <Button raised onClick={this.onClick}>
-                Build Query
-            </Button>
+            <div>
+                <Button raised disabled={!this.props.buttonActive} colored onClick={this.onClick}>
+                    Build Query
+                </Button>
+                <Dialog key="buildDialog" open={this.props.dialogOpen} onCancel={this.handleCloseDialog}>
+                    <DialogTitle component="h4">Do you want to send the following query to the KnowledgeStore?</DialogTitle>
+                    <DialogContent>
+                        <p>
+                            {(queryEntities.length > 0) ? <b>Entities</b> : <div />}
+                            {(queryEntities.length > 0) ? queryEntities : <div />}
+
+                            {(queryEvents.length > 0) ? <b>Events</b> : <div />}
+                            {(queryEvents.length > 0) ? queryEvents : <div />}
+
+                            {(querySources.length > 0) ? <b>Sources</b> : <div />}
+                            {(querySources.length > 0) ? querySources : <div />}
+
+                            {(queryTopics.length > 0) ? <b>Topics</b> : <div />}
+                            {(queryTopics.length > 0) ? queryTopics : <div />}
+                        </p>
+                        <p>
+                            <b>Resulting Query String:</b>
+                        </p>
+                        <p>
+                            {this.props.query.queryString}
+                        </p>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={this.clickStoreQuery}>Perform Query</Button>
+                        <Button onClick={this.handleCloseDialog}>Cancel</Button>
+                    </DialogActions>
+                </Dialog>
+            </div>
         );
     }
 }

--- a/src/components/QueryBuildButton.tsx
+++ b/src/components/QueryBuildButton.tsx
@@ -131,7 +131,7 @@ export class UnconnectedQueryBuildButton extends React.Component<IQueryBuildButt
                 <Dialog key="buildDialog" open={this.props.dialogOpen} onCancel={this.handleCloseDialog}>
                     <DialogTitle component="h4">Do you want to send the following query to the KnowledgeStore?</DialogTitle>
                     <DialogContent>
-                        <p>
+                        <div>
                             {(queryEntities.length > 0) ? <b>Entities</b> : <div />}
                             {(queryEntities.length > 0) ? queryEntities : <div />}
 
@@ -143,13 +143,13 @@ export class UnconnectedQueryBuildButton extends React.Component<IQueryBuildButt
 
                             {(queryTopics.length > 0) ? <b>Topics</b> : <div />}
                             {(queryTopics.length > 0) ? queryTopics : <div />}
-                        </p>
-                        <p>
+                        </div>
+                        <div>
                             <b>Resulting Query String:</b>
-                        </p>
-                        <p>
+                        </div>
+                        <div>
                             {this.props.query.queryString}
-                        </p>
+                        </div>
                     </DialogContent>
                     <DialogActions>
                         <Button onClick={this.clickStoreQuery}>Perform Query</Button>

--- a/src/components/QueryBuildButton.tsx
+++ b/src/components/QueryBuildButton.tsx
@@ -1,0 +1,56 @@
+import * as React                   from 'react';
+import { connect }                  from 'react-redux';
+import { Dispatch }                 from 'redux';
+
+import { IGenericAction }           from '../actions';
+import { buildQuery }               from '../actions';
+
+import { Button }                   from 'react-mdl';
+
+import './queryBuildButton.css';
+
+interface IQueryBuildButtonDispatchProps {
+    buildQuery: () => void;
+}
+
+export interface IQueryBuildButton {
+    id: number;
+}
+
+export class UnconnectedQueryBuildButton extends React.Component<IQueryBuildButton & IQueryBuildButtonDispatchProps, {}> {
+    constructor() {
+        super();
+
+        this.onClick = this.onClick.bind(this);
+    }
+
+    static mapStateToProps() { //state: IStore) {
+        return {
+            id:  -1
+        };
+    }
+
+    static mapDispatchToProps(dispatch: Dispatch<IGenericAction>) {
+        return {
+            buildQuery: () => {
+                dispatch(buildQuery());
+            }
+        };
+    }
+
+    public onClick() {
+        this.props.buildQuery();
+    }
+
+    render() {
+        return (
+            <Button raised onClick={this.onClick}>
+                Build Query
+            </Button>
+        );
+    }
+}
+
+// Export just the connected component
+export const QueryBuildButton = connect(UnconnectedQueryBuildButton.mapStateToProps,
+                                        UnconnectedQueryBuildButton.mapDispatchToProps)(UnconnectedQueryBuildButton);

--- a/src/components/QueryClearButton.tsx
+++ b/src/components/QueryClearButton.tsx
@@ -1,0 +1,114 @@
+import * as React                   from 'react';
+
+import { connect }                  from 'react-redux';
+import { Dispatch }                 from 'redux';
+
+import { IGenericAction }           from '../actions';
+import { clearQuery }               from '../actions';
+import { openClearQueryDialog }     from '../actions';
+import { closeClearQueryDialog }    from '../actions';
+
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from 'react-mdl';
+
+import { IStore }                   from '../interfaces';
+
+import './queryClearButton.css';
+import './queryDialog.css';
+
+interface IQueryClearButtonDispatchProps {
+    clearQuery: () => void;
+    openDialog: () => void;
+    closeDialog: () => void;
+}
+
+export interface IQueryClearButton {
+    id: number;
+    query: any;
+    dialogOpen: boolean;
+    buttonActive: boolean;
+}
+
+export class UnconnectedQueryClearButton extends React.Component<IQueryClearButton & IQueryClearButtonDispatchProps, {}> {
+    constructor() {
+        super();
+
+        this.onClick = this.onClick.bind(this);
+        this.clickClearQuery = this.clickClearQuery.bind(this);
+        this.handleOpenDialog = this.handleOpenDialog.bind(this);
+        this.handleCloseDialog = this.handleCloseDialog.bind(this);
+    }
+
+    static shouldButtonBeActive(state: IStore): boolean {
+        if ((state.queryState.entities  && state.queryState.entities.length > 0) ||
+            (state.queryState.events    && state.queryState.events.length > 0) ||
+            (state.queryState.sources   && state.queryState.sources.length > 0) ||
+            (state.queryState.topics    && state.queryState.topics.length > 0)) {
+            return true;
+        }
+        return false;
+    }
+
+    static mapStateToProps(state: IStore) { //state: IStore) {
+        return {
+            id:  -1,
+            query: state.queryState,
+            dialogOpen: state.queryState.isQueryClearDialogOpen,
+            buttonActive: UnconnectedQueryClearButton.shouldButtonBeActive(state)
+        };
+    }
+
+    static mapDispatchToProps(dispatch: Dispatch<IGenericAction>) {
+        return {
+            clearQuery: () => {
+                dispatch(clearQuery());
+            },
+            openDialog: () => {
+                dispatch(openClearQueryDialog());
+            },
+            closeDialog: () => {
+                dispatch(closeClearQueryDialog());
+            }
+        };
+    }
+
+    public onClick() {
+        this.props.openDialog();
+    }
+
+    public clickClearQuery() {
+      this.props.clearQuery();
+      this.props.closeDialog();
+    }
+
+    public handleOpenDialog() {
+        this.props.openDialog();
+    }
+
+    public handleCloseDialog() {
+        this.props.closeDialog();
+    }
+
+    render() {
+        return (
+            <div>
+                <Button raised disabled={!this.props.buttonActive} accent onClick={this.onClick}>
+                    Clear Query
+                </Button>
+                <Dialog key="clearDialog" open={this.props.dialogOpen} onCancel={this.handleCloseDialog}>
+                    <DialogTitle component="h4">You are about to clear your query. Are you sure?</DialogTitle>
+                    <DialogContent>
+                        You will not be able to undo this action.
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={this.clickClearQuery}>Clear Query</Button>
+                        <Button onClick={this.handleCloseDialog}>Cancel</Button>
+                    </DialogActions>
+                </Dialog>
+            </div>
+        );
+    }
+}
+
+// Export just the connected component
+export const QueryClearButton = connect(UnconnectedQueryClearButton.mapStateToProps,
+                                        UnconnectedQueryClearButton.mapDispatchToProps)(UnconnectedQueryClearButton);

--- a/src/components/Searchbox.tsx
+++ b/src/components/Searchbox.tsx
@@ -1,0 +1,63 @@
+import * as React                   from 'react';
+
+import { connect }                  from 'react-redux';
+import { Dispatch }                 from 'redux';
+
+import { IGenericAction }           from '../actions';
+import { textSearchThunk }               from '../actions';
+
+import { Textfield }                from 'react-mdl';
+
+import './searchbox.css';
+
+interface ISearchboxDispatchProps {
+    textSearch: (input: string) => void;
+}
+
+export interface ISearchbox {
+    id: number;
+}
+
+export class UnconnectedSearchbox extends React.Component<ISearchbox & ISearchboxDispatchProps, {}> {
+    constructor() {
+        super();
+        this.handleTextChange = this.handleTextChange.bind(this);
+    }
+
+    static mapStateToProps() { //state: IStore) {
+        return {
+            id:  -1
+        };
+    }
+
+    static mapDispatchToProps(dispatch: Dispatch<IGenericAction>) {
+        return {
+            textSearch: (input: string) => {
+                dispatch(textSearchThunk('entities', input));
+                dispatch(textSearchThunk('events', input));
+                dispatch(textSearchThunk('sources', input));
+                dispatch(textSearchThunk('topics', input));
+            }
+        };
+    }
+
+    public handleTextChange(event : any) {
+        this.props.textSearch(event.target.value);
+    }
+
+    render() {
+        return (
+            <Textfield
+                className="searchbox"
+                key="SearchboxTextfield"
+                onChange={this.handleTextChange}
+                label="Search for..."
+                style={{width: '200px'}}
+            />
+        );
+    }
+}
+
+// Export just the connected component
+export const Searchbox = connect(UnconnectedSearchbox.mapStateToProps,
+                                 UnconnectedSearchbox.mapDispatchToProps)(UnconnectedSearchbox);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,3 +7,4 @@ export { NodeCheckbox }  from './NodeCheckbox';
 export { MentionCounter }  from './MentionCounter';
 export { QueryBuildButton }  from './QueryBuildButton';
 export { QueryClearButton }  from './QueryClearButton';
+export { Searchbox }  from './Searchbox';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,4 +3,7 @@ export { Node }  from './Node';
 export { NodeCategory }  from './NodeCategory';
 export { NodeInstance }  from './NodeInstance';
 export { NodeCheckbox }  from './NodeCheckbox';
+
+export { MentionCounter }  from './MentionCounter';
 export { QueryBuildButton }  from './QueryBuildButton';
+export { QueryClearButton }  from './QueryClearButton';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ export { Node }  from './Node';
 export { NodeCategory }  from './NodeCategory';
 export { NodeInstance }  from './NodeInstance';
 export { NodeCheckbox }  from './NodeCheckbox';
+export { QueryBuildButton }  from './QueryBuildButton';

--- a/src/components/mentionCounter.css
+++ b/src/components/mentionCounter.css
@@ -1,0 +1,11 @@
+.mdl-textfield {
+    position: relative;
+    font-size: 16px;
+    display: inline-block;
+    box-sizing: border-box;
+    width: 300px;
+    max-width: 100%;
+    margin: 0;
+    /*padding: 20px 0;*/
+    padding: 10px 0;
+}

--- a/src/components/node.css
+++ b/src/components/node.css
@@ -8,3 +8,11 @@
   flex-flow: row wrap;
   justify-content: space-between;
 }
+
+.highlighted {
+  background-color:darkred;
+}
+
+.notHighlighted {
+  background-color:white;
+}

--- a/src/components/queryDialog.css
+++ b/src/components/queryDialog.css
@@ -1,0 +1,13 @@
+.mdl-dialog {
+  border: none;
+  box-shadow: 0 9px 46px 8px rgba(0, 0, 0, 0.14), 0 11px 15px -7px rgba(0, 0, 0, 0.12), 0 24px 38px 3px rgba(0, 0, 0, 0.2);
+  /*width: 280px; */
+  width: 500px; 
+}
+
+.mdl-dialog__title {
+    padding: 24px 24px 0;
+    margin: 0;
+    /* font-size: 2.5rem; */
+    font-size: 2rem; 
+}

--- a/src/components/searchbox.css
+++ b/src/components/searchbox.css
@@ -1,3 +1,3 @@
-.mentioncounter {
+.searchbox {
   margin-top: -15px;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,31 +2,44 @@ import '../node_modules/react-mdl/extra/material.css';
 import '../node_modules/react-mdl/extra/material.js';
 import './index.css';
 
-import * as React      from 'react';
-import * as ReactDOM   from 'react-dom';
-import { Provider }    from 'react-redux';
+import * as React       from 'react';
+import * as ReactDOM    from 'react-dom';
+import { Provider }     from 'react-redux';
 
-import { Node }        from './components';
-import { store }       from './store';
+import { Node }         from './components';
+import { QueryBuildButton } from './components';
+import { store }        from './store';
 
-import { Cell, Grid }               from 'react-mdl';
+import { Cell, Grid }   from 'react-mdl';
 
 ReactDOM.render(
     <Provider store={store}>
-        <Grid>
-            <Cell col={3}>
-                <Node key={1} table={'entities'} nodeID={1} />
-            </Cell>
-            <Cell col={3}>
-                <Node key={1} table={'events'} nodeID={1} />
-            </Cell>
-            <Cell col={3}>
-                <Node key={1} table={'sources'} nodeID={1} />
-            </Cell>
-            <Cell col={3}>
-                <Node key={1} table={'topics'} nodeID={1} />
-            </Cell>
-        </Grid>
+        <div>
+            <Grid>
+                <Cell col={9} />
+                <Cell col={3}>
+                    <QueryBuildButton />
+                </Cell>
+            </Grid>
+            <Grid>
+                <Cell col={3}>
+                    Entities
+                    <Node key={1} table={'entities'} nodeID={1} />
+                </Cell>
+                <Cell col={3}>
+                    Events
+                    <Node key={1} table={'events'} nodeID={1} />
+                </Cell>
+                <Cell col={3}>
+                    Sources
+                    <Node key={1} table={'sources'} nodeID={1} />
+                </Cell>
+                <Cell col={3}>
+                    Topics
+                    <Node key={1} table={'topics'} nodeID={1} />
+                </Cell>
+            </Grid>
+        </div>
     </Provider>,
     document.getElementById('root')
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import * as ReactDOM    from 'react-dom';
 import { Provider }     from 'react-redux';
 
 import { Node }         from './components';
-import { QueryBuildButton } from './components';
+import { MentionCounter, QueryBuildButton, QueryClearButton } from './components';
 import { store }        from './store';
 
 import { Cell, Grid }   from 'react-mdl';
@@ -16,7 +16,13 @@ ReactDOM.render(
     <Provider store={store}>
         <div>
             <Grid>
-                <Cell col={9} />
+                <Cell col={3}>
+                    <QueryClearButton />
+                </Cell>
+                <Cell col={3} />
+                <Cell col={3}>
+                    <MentionCounter />
+                </Cell>
                 <Cell col={3}>
                     <QueryBuildButton />
                 </Cell>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import * as ReactDOM    from 'react-dom';
 import { Provider }     from 'react-redux';
 
 import { Node }         from './components';
-import { MentionCounter, QueryBuildButton, QueryClearButton } from './components';
+import { MentionCounter, QueryBuildButton, QueryClearButton, Searchbox } from './components';
 import { store }        from './store';
 
 import { Cell, Grid }   from 'react-mdl';
@@ -19,7 +19,9 @@ ReactDOM.render(
                 <Cell col={3}>
                     <QueryClearButton />
                 </Cell>
-                <Cell col={3} />
+                <Cell col={3}>
+                    <Searchbox />
+                </Cell>
                 <Cell col={3}>
                     <MentionCounter />
                 </Cell>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -16,24 +16,10 @@ export interface IDatabaseRecord {
     url:            string;
 }
 
-// export interface INode {
-//     childof: number;
-//     id: number;
-//     isentity: boolean;
-//     isleaf: boolean;
-//     isinstance: boolean;
-//     level: number;
-//     mentioncount: number;
-//     name: string;
-//     url: string;
-//     isexpanded: boolean;
-//     selectionState: SelectionState;
-//     children: INode[];
-// }
-
 export interface IStore {
     entities: any;
     events: any;
     sources: any;
     topics: any;
+    queryState: any;
 }

--- a/src/reducers/allreducers.ts
+++ b/src/reducers/allreducers.ts
@@ -1,10 +1,25 @@
-import { combineReducers }          from 'redux';
+import { queryReducer }         from '../reducers';
+import { nodesReducerFactory }  from '../reducers';
 
-import { nodesReducerFactory }      from '../reducers';
+import { IGenericAction } from '../actions';
 
-export const allreducers = combineReducers ({
-    entities:   nodesReducerFactory('entities'),
-    events:     nodesReducerFactory('events'),
-    sources:    nodesReducerFactory('sources'),
-    topics:     nodesReducerFactory('topics')
-});
+const initstate: any = {
+    entities: {},
+    events: {},
+    sources: {},
+    topics: {},
+    queryState: {}
+};
+
+function combinedReducer(state: any = initstate, action: IGenericAction) {
+    return {
+        entities:   nodesReducerFactory('entities')(state.entities, action),
+        events:     nodesReducerFactory('events')(state.events, action),
+        sources:    nodesReducerFactory('sources')(state.sources, action),
+        topics:     nodesReducerFactory('topics')(state.topics, action),
+
+        queryState:  queryReducer(state, action)
+    };
+}
+
+export const allreducers = combinedReducer;

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,2 +1,3 @@
 export { nodesReducerFactory } from './nodesReducerFactory';
+export { queryReducer } from './queryReducer';
 export { allreducers }  from './allreducers';

--- a/src/reducers/queryReducer.ts
+++ b/src/reducers/queryReducer.ts
@@ -1,10 +1,10 @@
-import { CLEAR_QUERY }          from '../actions';
-import { BUILD_QUERY }          from '../actions';
-import { STORE_QUERY }          from '../actions';
-import { OPEN_BUILD_QUERY_DIALOG }    from '../actions';
-import { OPEN_CLEAR_QUERY_DIALOG }    from '../actions';
-import { CLOSE_BUILD_QUERY_DIALOG }   from '../actions';
-import { CLOSE_CLEAR_QUERY_DIALOG }   from '../actions';
+import { CLEAR_QUERY }                  from '../actions';
+import { BUILD_QUERY }                  from '../actions';
+import { STORE_QUERY }                  from '../actions';
+import { OPEN_BUILD_QUERY_DIALOG }      from '../actions';
+import { OPEN_CLEAR_QUERY_DIALOG }      from '../actions';
+import { CLOSE_BUILD_QUERY_DIALOG }     from '../actions';
+import { CLOSE_CLEAR_QUERY_DIALOG }     from '../actions';
 
 import { IGenericAction } from '../actions';
 
@@ -119,6 +119,7 @@ export const queryReducer =  (state: any = initstate, action: IGenericAction) =>
     } else if (action.type === CLOSE_CLEAR_QUERY_DIALOG) {
         return Object.assign({}, state.queryState, {isQueryClearDialogOpen: false});
     } else if (action.type === STORE_QUERY) {
+        //Needs something done
         return state.queryState;
     } else {
         return state.queryState;

--- a/src/reducers/queryReducer.ts
+++ b/src/reducers/queryReducer.ts
@@ -1,11 +1,21 @@
-import { BUILD_QUERY }    from '../actions';
+import { CLEAR_QUERY }          from '../actions';
+import { BUILD_QUERY }          from '../actions';
+import { STORE_QUERY }          from '../actions';
+import { OPEN_BUILD_QUERY_DIALOG }    from '../actions';
+import { OPEN_CLEAR_QUERY_DIALOG }    from '../actions';
+import { CLOSE_BUILD_QUERY_DIALOG }   from '../actions';
+import { CLOSE_CLEAR_QUERY_DIALOG }   from '../actions';
 
 import { IGenericAction } from '../actions';
 
 import { INode }          from '../components/Node';
 import { SelectionState } from '../interfaces';
 
-const initstate: any = {};
+const initstate: any = {
+    isQueryDialogOpen: false,
+    selectedMentionCount: 0,
+    queryString: ''
+};
 
 function aggregateSelected(nodes : any, node: INode) : INode[] {
     if (node.selectionState === SelectionState.Selected) {
@@ -25,8 +35,59 @@ function aggregateSelected(nodes : any, node: INode) : INode[] {
     }
 }
 
+function countMentions(state: any) : number {
+    let result : number = 0;
+    state.entities.forEach((entity: any) => {
+        result += entity.mentioncount;
+    });
+    state.events.forEach((event: any) => {
+        result += event.mentioncount;
+    });
+    state.sources.forEach((source: any) => {
+        result += source.mentioncount;
+    });
+    state.topics.forEach((topic: any) => {
+        result += topic.mentioncount;
+    });
+    return result;
+}
+
+function createQueryString(state: any) : string {
+    let result : string = '';
+    if (state.entities && state.entities.length > 0) {
+        result += ' --entityPhrase ';
+        state.entities.forEach((entity: any) => {
+            result += entity.name + ';';
+        });
+    }
+
+    if (state.events && state.events.length > 0) {
+        result += ' --eventPhrase ';
+        state.events.forEach((event: any) => {
+            result += event.name + ';';
+        });
+    }
+
+    if (state.sources && state.sources.length > 0) {
+        result += ' --authorPhrase ';
+        state.sources.forEach((source: any) => {
+            result += source.name + ';';
+        });
+    }
+
+    if (state.topics && state.topics.length > 0) {
+        result += ' --topic ';
+        state.topics.forEach((topic: any) => {
+            result += topic.name + ';';
+        });
+    }
+    return result;
+}
+
 export const queryReducer =  (state: any = initstate, action: IGenericAction) => {
-    if (action.type === BUILD_QUERY) {
+    if (action.type === CLEAR_QUERY) {
+        return Object.assign({}, initstate);
+    } else if (action.type === BUILD_QUERY) {
         const newQueryState = Object.assign({}, state.queryState);
 
         if (state.entities[1]) {
@@ -45,7 +106,20 @@ export const queryReducer =  (state: any = initstate, action: IGenericAction) =>
             newQueryState.topics = aggregateSelected(state.topics, state.topics[1]);
         }
 
+        newQueryState.selectedMentionCount = countMentions(newQueryState);
+        newQueryState.queryString = createQueryString(newQueryState);
+
         return newQueryState;
+    } else if (action.type === OPEN_BUILD_QUERY_DIALOG) {
+        return Object.assign({}, state.queryState, {isQueryBuildDialogOpen: true});
+    } else if (action.type === OPEN_CLEAR_QUERY_DIALOG) {
+        return Object.assign({}, state.queryState, {isQueryClearDialogOpen: true});
+    } else if (action.type === CLOSE_BUILD_QUERY_DIALOG) {
+        return Object.assign({}, state.queryState, {isQueryBuildDialogOpen: false});
+    } else if (action.type === CLOSE_CLEAR_QUERY_DIALOG) {
+        return Object.assign({}, state.queryState, {isQueryClearDialogOpen: false});
+    } else if (action.type === STORE_QUERY) {
+        return state.queryState;
     } else {
         return state.queryState;
     }

--- a/src/reducers/queryReducer.ts
+++ b/src/reducers/queryReducer.ts
@@ -1,0 +1,52 @@
+import { BUILD_QUERY }    from '../actions';
+
+import { IGenericAction } from '../actions';
+
+import { INode }          from '../components/Node';
+import { SelectionState } from '../interfaces';
+
+const initstate: any = {};
+
+function aggregateSelected(nodes : any, node: INode) : INode[] {
+    if (node.selectionState === SelectionState.Selected) {
+        return [node];
+    } else if (node.selectionState === SelectionState.Unselected) {
+        return [];
+    } else { // selectionState must be partial
+        const childIDs = node.children;
+
+        let result : INode[] = [];
+        childIDs.forEach((childID: number) => {
+            const childNode = nodes[childID];
+            result = result.concat(aggregateSelected(nodes, childNode));
+        });
+
+        return result;
+    }
+}
+
+export const queryReducer =  (state: any = initstate, action: IGenericAction) => {
+    if (action.type === BUILD_QUERY) {
+        const newQueryState = Object.assign({}, state.queryState);
+
+        if (state.entities[1]) {
+            newQueryState.entities = aggregateSelected(state.entities, state.entities[1]);
+        }
+
+        if (state.events[1]) {
+            newQueryState.events = aggregateSelected(state.events, state.events[1]);
+        }
+
+        if (state.sources[1]) {
+            newQueryState.sources = aggregateSelected(state.sources, state.sources[1]);
+        }
+
+        if (state.entities[1]) {
+            newQueryState.topics = aggregateSelected(state.topics, state.topics[1]);
+        }
+
+        return newQueryState;
+    } else {
+        return state.queryState;
+    }
+};

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,41 +6,11 @@ import { allreducers }          from './reducers';
 
 import { rootRequestedThunk }   from './actions';
 
-import { INode }                from './components/Node';
-import { SelectionState }       from './interfaces';
-
 export const store = createStore(allreducers, applyMiddleware(thunk));
-
-function aggregateSelected(nodes : any, node: INode) : INode[] {
-    if (node.selectionState === SelectionState.Selected) {
-        return [node];
-    } else if (node.selectionState === SelectionState.Unselected) {
-        return [];
-    } else { // selectionState must be partial
-        const childIDs = node.children;
-
-        let result : INode[] = [];
-        childIDs.forEach((childID) => {
-            const childNode = nodes[childID];
-            result = result.concat(aggregateSelected(nodes, childNode));
-        });
-
-        return result;
-    }
-}
 
 // whenever the store has changed, print the new state
 store.subscribe(() => {
     console.log(store.getState());
-
-    //tryout function to gather selected items    
-    const entityNodes = store.getState().entities;
-    const root = entityNodes[1];
-    if (root) {
-        const selectedNodes : INode[] = aggregateSelected(entityNodes, root);
-
-        console.log(selectedNodes);
-    }
 });
 
 store.dispatch(rootRequestedThunk('entities'));


### PR DESCRIPTION
- Changed allreducers from combinedReducer to slicedReducer form to allow sharing of state, 
- Added Button to manually gather selected nodes. 

```
State space is now:
state:
    entities: {
        textSearchResults: string[],
        [number] objectId ...
    },
    events: {
        textSearchResults: string[],
        [number] objectId ...
    },
    topics: {
        textSearchResults: string[],
        [number] objectId ...
    },
    sources: {
        textSearchResults: string[],
        [number] objectId ...
     },
    queryState: {
        isQueryBuildDialogOpen : boolean,
        isQueryClearDialogOpen: boolean,
        isQueryDialogOpen: boolean,
        queryString: string,
        selectedMentionCount: number,
        entities: [],
        events: [],
        topics: [],
        sources: []
    }
}
```
- Further logic behind query build action needed.